### PR TITLE
Java immutable set requires .size() instead of len().

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -322,8 +322,10 @@ class Item(Java_Item if TYPE_CHECKING else object):
 
     @_Tracing.javacall
     def linkChannel(self, channel_uid: str, link_config: dict[str, str] = {}) -> Java_ItemChannelLink:
-        link = Java_ItemChannelLink(self.getName(), Java_ChannelUID(channel_uid), Configuration(link_config))
-        links = ITEM_CHANNEL_LINK_REGISTRY.getLinks(channel_uid)
+        uid = Java_ChannelUID(channel_uid)
+        link = Java_ItemChannelLink(self.getName(), uid, Configuration(link_config))
+        links = ITEM_CHANNEL_LINK_REGISTRY.getLinks(uid)
+
         if links.size() > 0:
             if not links[0].getConfiguration().equals(link.getConfiguration()):
                 ITEM_CHANNEL_LINK_REGISTRY.update(link)

--- a/src/helper.py
+++ b/src/helper.py
@@ -324,7 +324,7 @@ class Item(Java_Item if TYPE_CHECKING else object):
     def linkChannel(self, channel_uid: str, link_config: dict[str, str] = {}) -> Java_ItemChannelLink:
         link = Java_ItemChannelLink(self.getName(), Java_ChannelUID(channel_uid), Configuration(link_config))
         links = ITEM_CHANNEL_LINK_REGISTRY.getLinks(channel_uid)
-        if len(links) > 0:
+        if links.size() > 0:
             if not links[0].getConfiguration().equals(link.getConfiguration()):
                 ITEM_CHANNEL_LINK_REGISTRY.update(link)
         else:

--- a/src/helper.py
+++ b/src/helper.py
@@ -326,6 +326,7 @@ class Item(Java_Item if TYPE_CHECKING else object):
         link = Java_ItemChannelLink(self.getName(), uid, Configuration(link_config))
         links = ITEM_CHANNEL_LINK_REGISTRY.getLinks(uid)
 
+
         if links.size() > 0:
             if not links[0].getConfiguration().equals(link.getConfiguration()):
                 ITEM_CHANNEL_LINK_REGISTRY.update(link)

--- a/src/helper.py
+++ b/src/helper.py
@@ -325,8 +325,6 @@ class Item(Java_Item if TYPE_CHECKING else object):
         uid = Java_ChannelUID(channel_uid)
         link = Java_ItemChannelLink(self.getName(), uid, Configuration(link_config))
         links = ITEM_CHANNEL_LINK_REGISTRY.getLinks(uid)
-
-
         if links.size() > 0:
             if not links[0].getConfiguration().equals(link.getConfiguration()):
                 ITEM_CHANNEL_LINK_REGISTRY.update(link)


### PR DESCRIPTION
The set returned by getLinks doesn't like to be interrogated via pythons' len call.