### PR TITLE
Extend parsing of ChannelEventTrigger to support dimmer_switch_event.

### DIFF
--- a/src/triggers.py
+++ b/src/triggers.py
@@ -145,7 +145,8 @@ class ChannelEventTrigger(BaseTrigger):
 
     first_word = ["channel"]
     # @when("Channel hue:device:default:lamp1:color triggered START")
-    regex = r"^Channel\s+\"*(?P<channel_uid>\D\S*)\"*\s+triggered(?:\s+(?P<event>\w+))*$"
+    # @when("Channel hue:device:default:button1:dimmer_switch_event triggered 1002.0")
+    regex = r"^Channel\s+\"*(?P<channel_uid>\D\S*)\"*\s+triggered(?:\s+(?P<event>[.\w]+))*$"
 
 class SystemStartlevelTrigger(BaseTrigger):
     def __init__(self, startlevel: int, trigger_name: str = None):


### PR DESCRIPTION
Needed to handle events from a [Philips Hue Smart Button](https://www.amazon.co.uk/Philips-Hue-Lighting-Accessory-Wireless/dp/B09C3MJR24/ref=sr_1_42).

The corresponding item is defined as:
```
Number:Dimensionless HueButton_DimmerSwitch   "Switch state Button" (gHueButton) ["Control"] {channel="hue:device:default:HueButton:dimmer_switch"}
```

For reference, here are the events I see:
```
class HueButtonConst:
    """Hue Button Constants"""

    INITIAL_PRESSED = 1000.0
    HOLD = 1001.0
    SHORT_RELEASED = 1002.0
    LONG_RELEASED = 1003.0
```